### PR TITLE
Fix "expand/collapse all" buttons, remove for single marker group 243

### DIFF
--- a/langworld_db_pyramid/static/js/doculectMapAll.js
+++ b/langworld_db_pyramid/static/js/doculectMapAll.js
@@ -1,26 +1,9 @@
-import hideExpandCollapseContainer from "./tools/hideExpandCollapseContainer.js";
 import renderMapWithList from "./tools/renderMapWithList.js";
+import adjustInteractiveListForSolitaryGroup from "./tools/adjustInteractiveListForSolitaryGroup.js";
 
 renderMapWithList("all");
 
-/* using event listener to wait for DOM the template to be rendered
-PLUS a timeout to wait for data to be loaded and <ul>'s to be created.
-Returning a promise from `renderMapWithList` and using `.then()` on it doesn't work: 
-throws `<name of promise> is undefined`.
-TODO: maybe some changes could be made to `renderMapWithList()`
-*/
-window.addEventListener("DOMContentLoaded", () => {
-  setTimeout(() => {
-    // default behavior of list is to have all items collapsed. Here it's better to have them expanded
-    const markerGroups = document.querySelectorAll(
-      "ul.doculects-in-group.w3-ul.w3-hide"
-    );
-
-    markerGroups.forEach((ul) => {
-      ul.classList.remove("w3-hide");
-    });
-
-    // There is only one group of doculects, so "expand/collapse" buttons are not needed.
-    hideExpandCollapseContainer();
-  }, 750);
-});
+window.addEventListener(
+  "DOMContentLoaded",
+  adjustInteractiveListForSolitaryGroup
+);

--- a/langworld_db_pyramid/static/js/mapWithList/components/DoculectMap.js
+++ b/langworld_db_pyramid/static/js/mapWithList/components/DoculectMap.js
@@ -215,6 +215,9 @@ export default function DoculectMap({ mapDivID = "map-default" }) {
   };
 
   const addLegend = () => {
+    // legend not needed if this map is only intended to show a single group of doculects
+    if (allDoculectGroups.length === 1) return null;
+
     let legend = L.control({ position: "bottomright" });
 
     legend.onAdd = () => {

--- a/langworld_db_pyramid/static/js/mapWithList/components/DoculectMap.js
+++ b/langworld_db_pyramid/static/js/mapWithList/components/DoculectMap.js
@@ -82,15 +82,15 @@ export default function DoculectMap({ mapDivID = "map-default" }) {
     setDoculectGroupsInMapView(getGroupsInMapView());
 
     /* Motivation for setTimeout()
-    If user opens the map from a doculect profile, it is likely that their mouse will 
-    end up pointing at a random doculect on the map, thus triggering its popup to open.
-    This is because of the position of the link to the map in doculect profiles.
-    This means that the user will not see the popup for the doculect they were meant to see.
-    Adding the timeout leads to the following chain of events: 
-    1. A popup opens for a doculect that user's mouse is pointing at,
-    2. after 0.5 seconds a popup opens for the correct doculect (closing the previous one).
-    Timeout of less than 0.5 seconds might not be enough for the map to show the popup for 
-    the random doculect the user's mouse is pointing at.
+       If user opens the map from a doculect profile, it is likely that their mouse will
+       end up pointing at a random doculect on the map, thus triggering its popup to open.
+       This is because of the position of the link to the map in doculect profiles.
+       This means that the user will not see the popup for the doculect they were meant to see.
+       Adding the timeout leads to the following chain of events:
+       1. A popup opens for a doculect that user's mouse is pointing at,
+       2. after 0.5 seconds a popup opens for the correct doculect (closing the previous one).
+          Timeout of less than 0.5 seconds might not be enough for the map to show the popup for
+          the random doculect the user's mouse is pointing at.
      */
     setTimeout(() => {
       changeIconForDoculectToShow(idOfDoculectToShow);
@@ -101,14 +101,20 @@ export default function DoculectMap({ mapDivID = "map-default" }) {
       // only change context, the list rendering is called from parent
       setDoculectGroupsInMapView(getGroupsInMapView());
 
-      /* Reconnect "expand all" / "collapse all" buttons in case some groups reappeared on the map
-      that had previously disappeared from it during moving or zooming in. */
+      /* Reconnect "expand all" / "collapse all" buttons with all marker groups
+         currently in view.
+         This has to be done every time the set of marker groups changes.
+         Instead of checking whether the groups have changed (which will complicate the code),
+         we just do it every time after zooming/moving has occurred.
+      */
       connectExpandAndCollapseButtonsWithGroups();
 
       /* If this map is meant to show only one group of doculects (e.g. all doculects, query wizard)
-      and the preceding zooming in had made it disappear,
-      properties of the interactive list must be restored after zooming out again.*/
-      if (allDoculectGroups.length === 1) adjustInteractiveListForSolitaryGroup();
+         and the preceding zooming in had made it disappear,
+         properties of the interactive list must be restored after zooming out again.
+      */
+      if (allDoculectGroups.length === 1)
+        adjustInteractiveListForSolitaryGroup();
     });
   }, [allDoculectGroups, mapLoaded]);
 
@@ -177,8 +183,8 @@ export default function DoculectMap({ mapDivID = "map-default" }) {
           markerForDoculectIDRef.current[idOfDoculectToShow].setOpacity(1);
       });
       marker.on("mouseout", function (e) {
-        /* if marker corresponds to the doculect that needs to stay in focus,
-        don't do anything: it has to remain opaque and with pop-up open
+        /* If marker corresponds to the doculect that needs to stay in focus,
+           don't do anything: it has to remain opaque and with pop-up open
         */
         if (
           marker == markerForDoculectIDRef.current[idOfDoculectToShow] &&

--- a/langworld_db_pyramid/static/js/mapWithList/components/DoculectMap.js
+++ b/langworld_db_pyramid/static/js/mapWithList/components/DoculectMap.js
@@ -3,11 +3,12 @@ import {
   doculectGroupsInMapViewContext,
   idOfDoculectToOpenPopupOnMapContext,
 } from "../contexts.js";
+import connectExpandAndCollapseButtonsWithGroups from "../../tools/connectExpandAndCollapseButtonsToListsOfDoculects.js";
 
 const elem = React.createElement;
 
 export default function DoculectMap({ mapDivID = "map-default" }) {
-  const leafletFeatureGroupsRef = React.useRef([]);  // "featureGroup" in terms of Leaflet, not database
+  const leafletFeatureGroupsRef = React.useRef([]); // "featureGroup" in terms of Leaflet, not database
   const mapRef = React.useRef(null);
   const selectedMarker = React.useRef(null);
 
@@ -98,6 +99,10 @@ export default function DoculectMap({ mapDivID = "map-default" }) {
     mapRef.current.on("zoomend moveend", () => {
       // only change context, the list rendering is called from parent
       setDoculectGroupsInMapView(getGroupsInMapView());
+      /* "expand all" / "collapse all" buttons should be updated
+         in case some groups reappeared on the map.
+      */
+      connectExpandAndCollapseButtonsWithGroups();
     });
   }, [allDoculectGroups, mapLoaded]);
 
@@ -198,7 +203,9 @@ export default function DoculectMap({ mapDivID = "map-default" }) {
        which means that pie markers will simply cover the circles.
        This is exactly what we need.
     */
-    leafletFeatureGroupsRef.current.forEach(group => group.addTo(mapRef.current));
+    leafletFeatureGroupsRef.current.forEach((group) =>
+      group.addTo(mapRef.current)
+    );
   };
 
   const addLegend = () => {
@@ -208,14 +215,16 @@ export default function DoculectMap({ mapDivID = "map-default" }) {
       let div = L.DomUtil.create("div", "legend");
 
       // exclude compound values from legend
-      allDoculectGroups.filter(g => ! g["id"].includes("&")).forEach((group) => {
-        div.innerHTML += `<img src="${group['imgSrc']}" height="20px"/><span>${group["name"]}</span><br>`;
-      });
+      allDoculectGroups
+        .filter((g) => !g["id"].includes("&"))
+        .forEach((group) => {
+          div.innerHTML += `<img src="${group["imgSrc"]}" height="20px"/><span>${group["name"]}</span><br>`;
+        });
       return div;
     };
 
     legend.addTo(mapRef.current);
-  }
+  };
 
   const zoomMapToFitAllMarkers = () => {
     let allMarkers = [];

--- a/langworld_db_pyramid/static/js/mapWithList/components/DoculectMap.js
+++ b/langworld_db_pyramid/static/js/mapWithList/components/DoculectMap.js
@@ -3,6 +3,7 @@ import {
   doculectGroupsInMapViewContext,
   idOfDoculectToOpenPopupOnMapContext,
 } from "../contexts.js";
+import adjustInteractiveListForSolitaryGroup from "../../tools/adjustInteractiveListForSolitaryGroup.js";
 import connectExpandAndCollapseButtonsWithGroups from "../../tools/connectExpandAndCollapseButtonsToListsOfDoculects.js";
 
 const elem = React.createElement;
@@ -99,10 +100,15 @@ export default function DoculectMap({ mapDivID = "map-default" }) {
     mapRef.current.on("zoomend moveend", () => {
       // only change context, the list rendering is called from parent
       setDoculectGroupsInMapView(getGroupsInMapView());
-      /* "expand all" / "collapse all" buttons should be updated
-         in case some groups reappeared on the map.
-      */
+
+      /* Reconnect "expand all" / "collapse all" buttons in case some groups reappeared on the map
+      that had previously disappeared from it during moving or zooming in. */
       connectExpandAndCollapseButtonsWithGroups();
+
+      /* If this map is meant to show only one group of doculects (e.g. all doculects, query wizard)
+      and the preceding zooming in had made it disappear,
+      properties of the interactive list must be restored after zooming out again.*/
+      adjustInteractiveListForSolitaryGroup();
     });
   }, [allDoculectGroups, mapLoaded]);
 

--- a/langworld_db_pyramid/static/js/mapWithList/components/DoculectMap.js
+++ b/langworld_db_pyramid/static/js/mapWithList/components/DoculectMap.js
@@ -108,7 +108,7 @@ export default function DoculectMap({ mapDivID = "map-default" }) {
       /* If this map is meant to show only one group of doculects (e.g. all doculects, query wizard)
       and the preceding zooming in had made it disappear,
       properties of the interactive list must be restored after zooming out again.*/
-      adjustInteractiveListForSolitaryGroup();
+      if (allDoculectGroups.length === 1) adjustInteractiveListForSolitaryGroup();
     });
   }, [allDoculectGroups, mapLoaded]);
 

--- a/langworld_db_pyramid/static/js/queryWizardForm.js
+++ b/langworld_db_pyramid/static/js/queryWizardForm.js
@@ -1,3 +1,4 @@
+import adjustInteractiveListForSolitaryGroup from "./tools/adjustInteractiveListForSolitaryGroup.js";
 import getLocale from "./tools/getLocale.js";
 import queryWizardStrings from "./i18n/queryWizardStrings.js";
 import { urlTopic } from "./constants/pubSubTopics.js";
@@ -27,6 +28,7 @@ window.addEventListener("load", () => {
   form.onchange = () => {
     markLabelsOfCategories(); // to let the user see in which categories they have selected values
     PubSub.publish(urlTopic, generateFetchUrl()); // pass the result of calling the function, not the function itself
+    adjustInteractiveListForSolitaryGroup();
   };
   form.onsubmit = (e) => e.preventDefault();
 

--- a/langworld_db_pyramid/static/js/setUpExpandCollapseInInteractiveList.js
+++ b/langworld_db_pyramid/static/js/setUpExpandCollapseInInteractiveList.js
@@ -1,7 +1,4 @@
-/* This script is imported in a parent Jinja template,
-so including it without eventListener will cause it to run
-while the child template is still not fully rendered.
-*/
+import connectExpandAndCollapseButtonsToListsOfDoculects from "./tools/connectExpandAndCollapseButtonsToListsOfDoculects";
 
 function setUpExpandCollapseContainerInInteractiveList() {
   {
@@ -14,24 +11,7 @@ function setUpExpandCollapseContainerInInteractiveList() {
       setTimeout(setUpExpandCollapseContainerInInteractiveList, 100);
     }
 
-    const expandAllButton = document.getElementById(
-      "doculect-list-expand-all-button"
-    );
-    const collapseAllButton = document.getElementById(
-      "doculect-list-collapse-all-button"
-    );
-
-    expandAllButton.onclick = () => {
-      markerGroups.forEach((ul) => {
-        ul.classList.remove("w3-hide");
-      });
-    };
-
-    collapseAllButton.onclick = () => {
-      markerGroups.forEach((ul) => {
-        ul.classList.add("w3-hide");
-      });
-    };
+    connectExpandAndCollapseButtonsToListsOfDoculects();
 
     const expandCollapseContainer = document.getElementById(
       "doculect-list-expand-collapse-container"
@@ -41,4 +21,11 @@ function setUpExpandCollapseContainerInInteractiveList() {
   }
 }
 
-window.addEventListener("DOMContentLoaded", setUpExpandCollapseContainerInInteractiveList);
+/* This script is imported in a parent Jinja template,
+so including it without eventListener will cause it to run
+while the child template is still not fully rendered.
+*/
+window.addEventListener(
+  "DOMContentLoaded",
+  setUpExpandCollapseContainerInInteractiveList
+);

--- a/langworld_db_pyramid/static/js/setUpExpandCollapseInInteractiveList.js
+++ b/langworld_db_pyramid/static/js/setUpExpandCollapseInInteractiveList.js
@@ -1,4 +1,4 @@
-import connectExpandAndCollapseButtonsToListsOfDoculects from "./tools/connectExpandAndCollapseButtonsToListsOfDoculects";
+import connectExpandAndCollapseButtonsToListsOfDoculects from "./tools/connectExpandAndCollapseButtonsToListsOfDoculects.js";
 
 function setUpExpandCollapseContainerInInteractiveList() {
   {

--- a/langworld_db_pyramid/static/js/tools/adjustInteractiveListForSolitaryGroup.js
+++ b/langworld_db_pyramid/static/js/tools/adjustInteractiveListForSolitaryGroup.js
@@ -1,0 +1,28 @@
+/* If interactive list has only one group of doculects:
+   1. the only group of doculects can be expanded right away,
+      contrary to default behavior of having doculect groups collapsed
+   2. "expand/collapse" buttons are not needed.
+*/
+
+export default function adjustInteractiveListForSolitaryGroup() {
+
+  // 1. expand the only group of doculects
+  const group = document.querySelector("ul.doculects-in-group.w3-ul.w3-hide");
+  // make sure group is ready (it may take a while to fetch data)
+  if (group === null) {
+    setTimeout(adjustInteractiveListForSolitaryGroup, 100);
+  } else {
+    /* the following could be outside of 'if' 
+       but it would trigger error in console while group is null
+    */
+    group.classList.remove("w3-hide");
+
+    // 2. hide expand/collapse buttons
+    document
+      .getElementById("doculect-list-expand-collapse-container")
+      .classList.add("w3-hide");
+  }
+  // FIXME group is shown collapsed again if user zooms in so much
+  //  that there are no doculects to show and then zooms out again
+  // TODO add ID to ul so that solitary group can still be collapsed if user so wishes?
+}

--- a/langworld_db_pyramid/static/js/tools/adjustInteractiveListForSolitaryGroup.js
+++ b/langworld_db_pyramid/static/js/tools/adjustInteractiveListForSolitaryGroup.js
@@ -22,6 +22,4 @@ export default function adjustInteractiveListForSolitaryGroup() {
       .getElementById("doculect-list-expand-collapse-container")
       .classList.add("w3-hide");
   }
-  // FIXME group is shown collapsed again if user zooms in so much
-  //  that there are no doculects to show and then zooms out again
 }

--- a/langworld_db_pyramid/static/js/tools/adjustInteractiveListForSolitaryGroup.js
+++ b/langworld_db_pyramid/static/js/tools/adjustInteractiveListForSolitaryGroup.js
@@ -15,7 +15,6 @@ export default function adjustInteractiveListForSolitaryGroup() {
     /* the following could be outside of braces,
        but it would trigger error in console while group is null
     */
-    console.log("Expand doculects automatically")
     group.classList.remove("w3-hide");
 
     // 2. hide expand/collapse buttons

--- a/langworld_db_pyramid/static/js/tools/adjustInteractiveListForSolitaryGroup.js
+++ b/langworld_db_pyramid/static/js/tools/adjustInteractiveListForSolitaryGroup.js
@@ -12,7 +12,7 @@ export default function adjustInteractiveListForSolitaryGroup() {
   if (group === null) {
     setTimeout(adjustInteractiveListForSolitaryGroup, 100);
   } else {
-    /* the following could be outside of 'if' 
+    /* the following could be outside of braces,
        but it would trigger error in console while group is null
     */
     group.classList.remove("w3-hide");
@@ -24,5 +24,4 @@ export default function adjustInteractiveListForSolitaryGroup() {
   }
   // FIXME group is shown collapsed again if user zooms in so much
   //  that there are no doculects to show and then zooms out again
-  // TODO add ID to ul so that solitary group can still be collapsed if user so wishes?
 }

--- a/langworld_db_pyramid/static/js/tools/adjustInteractiveListForSolitaryGroup.js
+++ b/langworld_db_pyramid/static/js/tools/adjustInteractiveListForSolitaryGroup.js
@@ -15,11 +15,17 @@ export default function adjustInteractiveListForSolitaryGroup() {
     /* the following could be outside of braces,
        but it would trigger error in console while group is null
     */
+    console.log("Expand doculects automatically")
     group.classList.remove("w3-hide");
 
     // 2. hide expand/collapse buttons
     document
       .getElementById("doculect-list-expand-collapse-container")
+      .classList.add("w3-hide");
+
+    // 3. remove color marker from interactive list
+    document
+      .getElementsByClassName("icon-in-map-legend")[0]
       .classList.add("w3-hide");
   }
 }

--- a/langworld_db_pyramid/static/js/tools/connectExpandAndCollapseButtonsToListsOfDoculects.js
+++ b/langworld_db_pyramid/static/js/tools/connectExpandAndCollapseButtonsToListsOfDoculects.js
@@ -1,13 +1,10 @@
 export default function connectExpandAndCollapseButtonsToListsOfDoculects() {
   /* Update "expand all/collapse all" buttons by linking them
      to <ul>'s actually present in the DOM.
-     This has to be done every time something changes on the map
-     that makes some groups disappear from the interactive list,
-     not just when the map is first rendered.
   */
 
   const subListsOfDoculects = document.querySelectorAll(
-    "ul.doculects-in-group.w3-ul.w3-hide"
+    "ul.doculects-in-group.w3-ul"
   );
 
   const expandAllButton = document.getElementById(

--- a/langworld_db_pyramid/static/js/tools/connectExpandAndCollapseButtonsToListsOfDoculects.js
+++ b/langworld_db_pyramid/static/js/tools/connectExpandAndCollapseButtonsToListsOfDoculects.js
@@ -1,0 +1,31 @@
+export default function connectExpandAndCollapseButtonsToListsOfDoculects() {
+  /* Update "expand all/collapse all" buttons by linking them
+     to <ul>'s actually present in the DOM.
+     This has to be done every time something changes on the map
+     that makes some groups disappear from the interactive list,
+     not just when the map is first rendered.
+  */
+
+  const subListsOfDoculects = document.querySelectorAll(
+    "ul.doculects-in-group.w3-ul.w3-hide"
+  );
+
+  const expandAllButton = document.getElementById(
+    "doculect-list-expand-all-button"
+  );
+  const collapseAllButton = document.getElementById(
+    "doculect-list-collapse-all-button"
+  );
+
+  expandAllButton.onclick = () => {
+    subListsOfDoculects.forEach((ul) => {
+      ul.classList.remove("w3-hide");
+    });
+  };
+
+  collapseAllButton.onclick = () => {
+    subListsOfDoculects.forEach((ul) => {
+      ul.classList.add("w3-hide");
+    });
+  };
+}

--- a/langworld_db_pyramid/static/js/tools/hideExpandCollapseContainer.js
+++ b/langworld_db_pyramid/static/js/tools/hideExpandCollapseContainer.js
@@ -1,5 +1,0 @@
-export default function hideExpandCollapseContainer() {
-  document
-    .getElementById("doculect-list-expand-collapse-container")
-    .classList.add("w3-hide");
-}

--- a/langworld_db_pyramid/views/__init__.py
+++ b/langworld_db_pyramid/views/__init__.py
@@ -5,6 +5,8 @@ from pyramid.request import Request
 
 from langworld_db_pyramid.models import Doculect
 
+ID_TO_SHOW_ALL_DOCULECTS = "_all"
+
 
 def get_doculect_from_params(request: Request) -> Union[Doculect, None]:
     """Gets Doculect object by ID mentioned in URL param `?show_doculect=...`.

--- a/langworld_db_pyramid/views/doculects_map.py
+++ b/langworld_db_pyramid/views/doculects_map.py
@@ -9,7 +9,11 @@ from langworld_db_pyramid.dbutils.query_helpers import get_all
 from langworld_db_pyramid.locale.in_code_translation_strings import ALL_VISIBLE_DOCULECTS_HEADING
 from langworld_db_pyramid.maputils.marker_icons import generate_one_icon
 from langworld_db_pyramid.maputils.markers import generate_marker_group
-from langworld_db_pyramid.views import get_doculect_from_params, localized_name_case_insensitive
+from langworld_db_pyramid.views import (
+    ID_TO_SHOW_ALL_DOCULECTS,
+    get_doculect_from_params,
+    localized_name_case_insensitive,
+)
 
 
 @view_config(
@@ -36,7 +40,7 @@ def get_doculects_for_map(request: Request) -> list[dict[str, Any]]:
     return [
         generate_marker_group(
             request,
-            group_id="all",
+            group_id=ID_TO_SHOW_ALL_DOCULECTS,
             group_name=request.localizer.translate(ALL_VISIBLE_DOCULECTS_HEADING),
             doculects=sorted(doculects, key=localized_name_case_insensitive(request.locale_name)),
             div_icon_html=icon.svg_tag,

--- a/langworld_db_pyramid/views/doculects_map.py
+++ b/langworld_db_pyramid/views/doculects_map.py
@@ -36,7 +36,7 @@ def get_doculects_for_map(request: Request) -> list[dict[str, Any]]:
     return [
         generate_marker_group(
             request,
-            group_id="",
+            group_id="all",
             group_name=request.localizer.translate(ALL_VISIBLE_DOCULECTS_HEADING),
             doculects=sorted(doculects, key=localized_name_case_insensitive(request.locale_name)),
             div_icon_html=icon.svg_tag,

--- a/langworld_db_pyramid/views/families.py
+++ b/langworld_db_pyramid/views/families.py
@@ -8,9 +8,11 @@ from langworld_db_pyramid import models
 from langworld_db_pyramid.dbutils.query_helpers import get_all
 from langworld_db_pyramid.maputils.marker_icons import CLLDIcon, CLLDPie, icon_for_object
 from langworld_db_pyramid.maputils.markers import generate_marker_group
-from langworld_db_pyramid.views import get_doculect_from_params, localized_name_case_insensitive
-
-MATCHDICT_ID_FOR_ALL_FAMILIES = "_all"
+from langworld_db_pyramid.views import (
+    ID_TO_SHOW_ALL_DOCULECTS,
+    get_doculect_from_params,
+    localized_name_case_insensitive,
+)
 
 
 def _get_family_immediate_subfamilies_and_icons(
@@ -28,7 +30,7 @@ def _get_family_immediate_subfamilies_and_icons(
     """
     family_man_id = request.matchdict["family_man_id"]
 
-    if family_man_id == MATCHDICT_ID_FOR_ALL_FAMILIES:
+    if family_man_id == ID_TO_SHOW_ALL_DOCULECTS:
         family = None
         immediate_subfamilies = get_all(
             request, select(models.Family).where(models.Family.parent == family)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -13,7 +13,7 @@ from langworld_db_pyramid.views.doculects_list import (
 )
 from langworld_db_pyramid.views.doculects_map import get_doculects_for_map, view_all_doculects_map
 from langworld_db_pyramid.views.families import (
-    MATCHDICT_ID_FOR_ALL_FAMILIES,
+    ID_TO_SHOW_ALL_DOCULECTS,
     _get_family_immediate_subfamilies_and_icons,
     view_families_for_list,
     view_families_for_map,
@@ -206,7 +206,7 @@ def test_families__get_family_immediate_subfamilies_and_icons(
 ):
     dummy_request.matchdict["family_man_id"] = family_man_id
     parent, families, dict_with_icons = _get_family_immediate_subfamilies_and_icons(dummy_request)
-    if family_man_id == MATCHDICT_ID_FOR_ALL_FAMILIES:
+    if family_man_id == ID_TO_SHOW_ALL_DOCULECTS:
         assert parent is None
     else:
         assert parent.man_id == family_man_id
@@ -222,7 +222,7 @@ def test_families__get_family_immediate_subfamilies_and_icons_not_found(dummy_re
 @pytest.mark.parametrize(
     "family_man_id, parent_is_none, expected_number_of_families",
     [  # subtracted numbers indicate families that have no doculects with profiles and must not be in data['families']
-        (MATCHDICT_ID_FOR_ALL_FAMILIES, True, 13 - 2),
+        (ID_TO_SHOW_ALL_DOCULECTS, True, 13 - 2),
         ("isolate", False, 0),
         ("eskimo", False, 2 - 1),
         ("slav", False, 3),
@@ -259,7 +259,7 @@ def test_mapbox_token_get_mapbox_token(
     "family_man_id, expected_number_of_groups, expected_number_of_doculects",
     [
         (
-            MATCHDICT_ID_FOR_ALL_FAMILIES,
+            ID_TO_SHOW_ALL_DOCULECTS,
             NUMBER_OF_TEST_TOP_LEVEL_FAMILIES_WITH_FEATURE_PROFILES,
             NUMBER_OF_TEST_DOCULECTS_WITH_FEATURE_PROFILES,
         ),


### PR DESCRIPTION
fixes #245 
fixes #243 
fixes #4 
- [x] remove expand/collapse container from single-group maps
- [x] restore functionality of "expand all" / "collapse all" buttons after zooming/moving the map
- [x] expand single-group list again after moving or zooming in to show no doculects and then back in
- [x] remove legend from map and clickable group marker from interactive list
- [x] add the same functionality to query wizard
- [x] fix: markers in multi-group map stop being clickable and `ul`s not responding to "collapse all"